### PR TITLE
Fix thank-you page link

### DIFF
--- a/thank-you.html
+++ b/thank-you.html
@@ -15,6 +15,6 @@
 <body>
   <h1>Thank You!</h1>
   <p>Your message has been sent. We'll be in touch soon.</p>
-  <p><a href="https://hanshoyos.github.io/J-G-Trucking-and-Grading/">← Back to Home</a></p>
+  <p><a href="index.html">← Back to Home</a></p>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- fix broken link to home on the thank-you page

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_683f4fdb5f0c833293500b1ae5ed43f2