### PR TITLE
fix: add semicolon after nav variable declarations

### DIFF
--- a/index.html
+++ b/index.html
@@ -335,7 +335,7 @@ $(function () {
       $subNavToggleBtn = $parent.find('.sb-nav__sub-toggle'),
       $navigationWrapper = $("#sb-navigation"),
       $bannerWrapper = $("#sb-banner"),
-      $navigationSection = $("#sb-navigation > .sb-section")
+      $navigationSection = $("#sb-navigation > .sb-section");
 
   $navigationWrapper.find('.sb-section').css('transform', 'none'); // fix for when animations are applied
 
@@ -360,7 +360,7 @@ $(function () {
   });
 
   function toggleFixedNavigation () {
-    $navigationSection = $("#sb-navigation > .sb-section")
+    $navigationSection = $("#sb-navigation > .sb-section");
 
     // TODO: Simplify this in the future
     if ($("#sb-id-8dda839b-c486-40c0-a08a-8cfa194a910f").hasClass("option-nav-fixed") || $navigationSection.hasClass("option-nav-fixed")) {


### PR DESCRIPTION
## Summary
- fix missing semicolons for `$navigationSection` declarations in `index.html`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_683f53bba5a48332bdfa6177b3eac990